### PR TITLE
Add build instructions for fresh install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Frozen Electrocuted Combustion
+
+Dll for [Skyrim mod FEC](https://www.nexusmods.com/skyrimspecialedition/mods/3532) that applies visual effects to NPCs and the player, when killed by air, ash, dragons, drain, fire, frost, fear, lightning, poison, soultrap, steam and sun damage status effects.
+
+## Requirements
+* [CMake](https://cmake.org/)
+	* Add this to your `PATH`
+* [PowerShell](https://github.com/PowerShell/PowerShell/releases/latest)
+* [Vcpkg](https://github.com/microsoft/vcpkg)
+	* Add the environment variable `VCPKG_ROOT` with the value as the path to the folder containing vcpkg
+* [Visual Studio Community 2019](https://visualstudio.microsoft.com/)
+	* Desktop development with C++
+* [CommonLibSSE](https://github.com/powerof3/CommonLibSSE/tree/dev)
+	* You need to build from the powerof3/dev branch
+	* Add this as as an environment variable `CommonLibSSEPath`
+* [PapyrusExtender](https://github.com/powerof3/PapyrusExtenderSSE)
+	* Runtime requirement
+	* Also available [prebuilt](https://www.nexusmods.com/skyrimspecialedition/mods/22854)
+
+## Register Visual Studio as a Generator
+* Open `x64 Native Tools Command Prompt`
+* Run `cmake`
+* Close the cmd window
+
+## Building
+```
+git clone https://github.com/powerof3/FEC
+cd PapyrusExtenderSSE
+cmake -B build -S .
+```
+Open build/po3_FEC.sln in Visual Studio to build dll.
+
+## License
+[MIT](LICENSE)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -378,8 +378,8 @@ public:
 	{
 		std::vector<std::string> vec;
 
-		const auto papyrusExtenderHandle = GetModuleHandle(ver::PapyrusExtender.data());
-		const auto papyrusUtilsHandle = GetModuleHandle(ver::PapyrusUtil.data());
+		const auto papyrusExtenderHandle = GetModuleHandleA(ver::PapyrusExtender.data());
+		const auto papyrusUtilsHandle = GetModuleHandleA(ver::PapyrusUtil.data());
 
 		std::string message;
 		std::string info;
@@ -513,7 +513,7 @@ void OnInit(SKSE::MessagingInterface::Message* a_msg)
             const auto settings = Settings::GetSingleton();
 			if (settings->GetFormsFromMod()) {
 				constexpr auto get_tweaks_fix = []() {
-					const auto po3TweaksHandle = GetModuleHandle(ver::po3Tweaks.data());
+					const auto po3TweaksHandle = GetModuleHandleA(ver::po3Tweaks.data());
 					if (po3TweaksHandle == nullptr) {
 						return false;
 					}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,6 +7,7 @@
   "dependencies": [
     "boost-algorithm",
     "boost-stl-interfaces",
+    "frozen",
     "simpleini",
     "spdlog",
     "xbyak"


### PR DESCRIPTION
Tested on a fresh install of VS2019.

I had to change GetModuleHandle to GetModuleHandleA as it was being set to GetModuleHandleW because _UNICODE was being set by cmake. I don't think it'll impact anything, but wanted to flag that change.

